### PR TITLE
Add initial project structure with LICENSE and documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,32 @@
+# Project Overview
+
+## Introduction
+
+This project demonstrates the use of the 0.96" OLED display (SSD1306) embedded on the RoboCore BlackBoard Wisdom. The goal is to show how to initialize the display and update it in real-time using MicroPython.
+
+## Purpose
+
+The main objective is to build a simple counter that updates on the OLED screen every second. This example provides a foundation for more advanced applications involving I2C communication, graphic rendering, or dynamic data display on the screen.
+
+## Architecture
+
+The system is built using MicroPython and runs directly on the BlackBoard Wisdom microcontroller. It makes use of the following components:
+
+- **Microcontroller**: RoboCore BlackBoard Wisdom  
+- **Display**: 0.96" OLED SSD1306 (I2C interface)  
+- **I2C Pins**: SDA = GPIO21, SCL = GPIO22  
+- **Libraries**: `ssd1306`, `gfx`, `machine`, `time`, `sleep`
+
+## File Structure
+
+- `src/main.py`: Main script that initializes the display and runs the counter loop  
+- `src/button_rgb_led.py`: Contains code to control RGB LED colors using PWM  
+- `docs/overview.md`: This document, describing the project overview and architecture
+
+## Future Improvements
+
+- Add button support to control the counter
+- Integrate temperature or sensor data for dynamic display
+- Display graphics and custom animations
+- Modularize code for easier reuse in other Wisdom-based projects
+


### PR DESCRIPTION
This pull request introduces the initial structure of the Wisdom Display OLED project.

Changes included:
- Added LICENSE file (project license)
- Created `/docs/overview.md` with project overview and goals
- Structured the repository for documentation and source files

This setup prepares the repository for future code additions, documentation improvements, and feature expansion based on the RoboCore BlackBoard Wisdom platform.
